### PR TITLE
Use random IDs for filters and headers

### DIFF
--- a/Client/src/main/java/dev/blackilykat/pmp/client/ClientIds.java
+++ b/Client/src/main/java/dev/blackilykat/pmp/client/ClientIds.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Blackilykat and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.blackilykat.pmp.client;
+
+import dev.blackilykat.pmp.FilterInfo;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.IntPredicate;
+
+public final class ClientIds {
+	private ClientIds() {}
+
+	public static int randomFilterId() {
+		return randomUnusedId(id -> {
+			for(Filter filter : ClientStorage.MAIN.filters.get()) {
+				if(filter.id == id) {
+					return true;
+				}
+			}
+
+			for(FilterInfo filterInfo : ClientStorage.MAIN.lastKnownServerFilters.get()) {
+				if(filterInfo.id() == id) {
+					return true;
+				}
+			}
+
+			return false;
+		});
+	}
+
+	public static int randomHeaderId() {
+		return randomUnusedId(id -> {
+			for(Header header : ClientStorage.MAIN.headers.get()) {
+				if(header.id == id) {
+					return true;
+				}
+			}
+
+			return false;
+		});
+	}
+
+	private static int randomUnusedId(IntPredicate isUsed) {
+		int id;
+		do {
+			id = ThreadLocalRandom.current().nextInt(1, Integer.MAX_VALUE);
+		} while(isUsed.test(id));
+		return id;
+	}
+}

--- a/Client/src/main/java/dev/blackilykat/pmp/client/ClientStorage.java
+++ b/Client/src/main/java/dev/blackilykat/pmp/client/ClientStorage.java
@@ -52,8 +52,6 @@ public class ClientStorage {
 		public StoredMap<String, Track> tracks = new StoredMap<>(String.class, Track.class, this);
 		public StoredList<Header> headers = new StoredList<>(Header.class, this);
 		public StoredList<Filter> filters = new StoredList<>(Filter.class, this);
-		public StoredInt currentFilterID = new StoredInt(this, 0);
-		public StoredInt currentHeaderID = new StoredInt(this, 0);
 		public Stored<String> serverAddress = new Stored<>(String.class, this, "localhost");
 		public StoredInt serverPort = new StoredInt(this, PMPConnection.DEFAULT_MESSAGE_PORT);
 		public StoredInt serverFilePort = new StoredInt(this, PMPConnection.DEFAULT_FILE_PORT);

--- a/Client/src/main/java/dev/blackilykat/pmp/client/Filter.java
+++ b/Client/src/main/java/dev/blackilykat/pmp/client/Filter.java
@@ -43,7 +43,7 @@ public class Filter {
 	public String key;
 
 	public Filter(String key) {
-		this(ClientStorage.MAIN.currentFilterID.getAndIncrement(), key);
+		this(ClientIds.randomFilterId(), key);
 	}
 
 	@JsonCreator

--- a/Client/src/main/java/dev/blackilykat/pmp/client/Library.java
+++ b/Client/src/main/java/dev/blackilykat/pmp/client/Library.java
@@ -394,11 +394,10 @@ public class Library {
 
 
 			if(ClientStorage.MAIN.headers.empty()) {
-				ClientStorage.MAIN.headers.add(new Header(0, "N°", "tracknumber"));
-				ClientStorage.MAIN.headers.add(new Header(1, "Title", "title"));
-				ClientStorage.MAIN.headers.add(new Header(2, "Artist", "artist"));
-				ClientStorage.MAIN.headers.add(new Header(3, "Duration", "duration"));
-				ClientStorage.MAIN.currentHeaderID.set(4);
+				ClientStorage.MAIN.headers.add(new Header(ClientIds.randomHeaderId(), "N°", "tracknumber"));
+				ClientStorage.MAIN.headers.add(new Header(ClientIds.randomHeaderId(), "Title", "title"));
+				ClientStorage.MAIN.headers.add(new Header(ClientIds.randomHeaderId(), "Artist", "artist"));
+				ClientStorage.MAIN.headers.add(new Header(ClientIds.randomHeaderId(), "Duration", "duration"));
 			} else {
 				for(Header header : ClientStorage.MAIN.headers.get()) {
 					header.updateType();

--- a/Client/src/main/java/dev/blackilykat/pmp/client/gui/TracksPanel.java
+++ b/Client/src/main/java/dev/blackilykat/pmp/client/gui/TracksPanel.java
@@ -19,6 +19,7 @@ package dev.blackilykat.pmp.client.gui;
 
 import com.github.weisj.jsvg.view.ViewBox;
 import dev.blackilykat.pmp.Order;
+import dev.blackilykat.pmp.client.ClientIds;
 import dev.blackilykat.pmp.client.ClientStorage;
 import dev.blackilykat.pmp.client.Header;
 import dev.blackilykat.pmp.client.Library;
@@ -312,7 +313,7 @@ public class TracksPanel extends JPanel {
 				return;
 			}
 
-			Header header = new Header(ClientStorage.MAIN.currentHeaderID.getAndIncrement(), label.get(), key.get());
+			Header header = new Header(ClientIds.randomHeaderId(), label.get(), key.get());
 
 
 			Library.addHeader(header);


### PR DESCRIPTION
## Summary
- Generate random positive IDs for client-side filters and headers instead of using persisted counters
- Avoid reusing IDs that are already present locally, and for filters also avoid IDs from the last known server filter list
- Remove the now-unused filter/header ID counters from client storage

## Verification
- `gradlew.bat build --no-daemon --console=plain` with JDK 25.0.3

Closes #20